### PR TITLE
Extend images with PDF build reqs

### DIFF
--- a/nodepool/elements/otc-base/package-installs.yaml
+++ b/nodepool/elements/otc-base/package-installs.yaml
@@ -2,3 +2,9 @@ cloud-init:
 coreutils:
 bash:
 # network:
+latexmk:
+imagemagick:
+texlive-latex-base:
+texlive-latex-extra:
+texlive-xetex:
+texlive-fonts-recommended:

--- a/nodepool/elements/otc-base/pkg-map
+++ b/nodepool/elements/otc-base/pkg-map
@@ -4,7 +4,11 @@
       "cloud-init": "cloud-init",
       "dhcp-client": "dhclient",
       "network": "NetworkManager",
-      "coreutils": "coreutils"
+      "coreutils": "coreutils",
+      "imagemagick": "ImageMagick",
+      "texlive-fonts-recommended": "",
+      "texlive-latex-base": "",
+      "texlive-latex-extra": ""
     },
     "suse": {
       "cloud-init": "cloud-init",
@@ -17,11 +21,17 @@
     },
     "debian": {
       "cloud-init": "cloud-init",
-      "dhcp-client": "isc-dhcp-client"
+      "dhcp-client": "isc-dhcp-client",
+      "imagemagick": "imagemagick",
+      "texlive-fonts-recommended": "texlive-fonts-recommended",
+      "texlive-latex-base": "texlive-latex-base",
+      "texlive-latex-extra": "texlive-latex-extra"
     }
   },
   "default": {
     "cloud-init": "cloud-init",
-    "coreutils": ""
+    "coreutils": "";
+    "latexmk": "latexmk",
+    "texlive-xetex": "texlive-xetex"
   }
 }


### PR DESCRIPTION
We often need certain packages in order to build PDF docs. Installing
those in job is the best way, but is taking often too much time.
Pre-build few of the heaviest packages hoping that eventual update is
going to be much faster.
