### PR TITLE
chore: fix tls cert names

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -9,9 +9,9 @@ zookeeper-servers:
     port: 2281
 
 zookeeper-tls:
-  cert: /tls/client/zk.pem
-  key: /tls/client/zk.key
-  ca: /tls/client/ca.pem
+  cert: /tls/client/tls.crt
+  key: /tls/client/tls.key
+  ca: /tls/client/ca.crt
 
 diskimages:
   - name: base


### PR DESCRIPTION
previous change set the new path, but file name is also different