### PR TITLE
chore: use full path in zuul config script

### DIFF
--- a/tools/render_config.py
+++ b/tools/render_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import argparse
 from pathlib import Path
 import yaml
 
@@ -50,7 +51,17 @@ def merge(src: str):
 
 
 def main():
-    config = merge("zuul")
+    parser = argparse.ArgumentParser(
+        prog="Zuul tenant generator",
+        description="Render Zuul tenant configuration from elements",
+    )
+    parser.add_argument(
+        "--dir",
+        default="/etc/zuul-config/zuul",
+        help=("Base directory with configuration elements")
+    )
+    args = parser.parse_args()
+    config = merge(args.dir)
     print(yaml.dump(config))
 
 


### PR DESCRIPTION
zuul config loading from scirpt is not having possibility to use cwd or
pass any additional args. Therefore add argparser to with default
location in the container where script and data are being mounted.
