### PR TITLE
remove python 3.11 from f37

### DIFF
--- a/containers/Dockerfile.f37
+++ b/containers/Dockerfile.f37
@@ -5,8 +5,9 @@ RUN dnf update -y && dnf install -y iproute rsync git traceroute unzip bzip2 \
   bzip2-devel libffi-devel sqlite-devel sqlite-devel rpm-sign expect \
   make curl wget tar procps-ng which sudo unzip findutils grep ncurses-devel \
   openssl-devel zlib-devel krb5-devel make cmake gcc gcc-c++ rpm-build \
-  python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3-dnf \
+  python3.6 python3.7 python3.8 python3.9 python3.10 python3-dnf \
   python3-setuptools python3 python3-devel python3-wheel python3-pip && \
+  dnf remove python3.11 && \
   dnf clean all
 
 RUN ln -sf /bin/pip3 /bin/pip && /bin/pip3 install --user 'tox>=3.8.0' os-testr

--- a/containers/Dockerfile.f37
+++ b/containers/Dockerfile.f37
@@ -7,7 +7,6 @@ RUN dnf update -y && dnf install -y iproute rsync git traceroute unzip bzip2 \
   openssl-devel zlib-devel krb5-devel make cmake gcc gcc-c++ rpm-build \
   python3.6 python3.7 python3.8 python3.9 python3.10 python3-dnf \
   python3-setuptools python3 python3-devel python3-wheel python3-pip && \
-  dnf remove python3.11 && \
   dnf clean all
 
 RUN ln -sf /bin/pip3 /bin/pip && /bin/pip3 install --user 'tox>=3.8.0' os-testr


### PR DESCRIPTION
tox jobs are failing when using python 3.11