### PR TITLE
fix(eco): load system-config config despite private repo (exclude-unprotected-branches=false, include main)

### DIFF
--- a/zuul/tenants/eco/sources/github/untrusted-projects/opentelekomcloud-infra/system-config.yaml
+++ b/zuul/tenants/eco/sources/github/untrusted-projects/opentelekomcloud-infra/system-config.yaml
@@ -1,0 +1,9 @@
+# system-config is private (GitHub Free plan) so branch protection is
+# unavailable and every branch reports as unprotected. The eco tenant sets
+# exclude-unprotected-branches: true, which was silently dropping all of
+# system-config's config (infra-prod-* jobs + periodic service-deploy
+# project) once the repo went private. Override it here and pin to main
+# (the branch the infra-prod jobs live on) to avoid parsing every branch.
+exclude-unprotected-branches: false
+include-branches:
+  - main


### PR DESCRIPTION
## Problem
On the eco tenant (otcci prod Zuul), all system-config jobs vanished: `infra-prod-base` returns 500 and there are **0** `infra-prod-*` / `system-config-*` jobs. The periodic service-deployment jobs stopped running.

## Root cause
system-config was made **private**. On GitHub Free, branch protection is unavailable, so every branch reports as unprotected. The eco `tenant.yaml` has `exclude-unprotected-branches: true`, so Zuul now **excludes all of system-config's branches** and silently drops its config (jobs + periodic project) — no config-error because the branch is skipped entirely.

## Fix
Per-project override on the eco system-config untrusted-project: `exclude-unprotected-branches: false` + `include-branches: [main]` (system-config has hundreds of branches; pin to main where the infra-prod jobs live). Same fix pattern used on eco2.